### PR TITLE
Added Cannot Leech Life/Mana mods in initial ModWarnings.txt config

### DIFF
--- a/Configs.cs
+++ b/Configs.cs
@@ -60,6 +60,8 @@ namespace MapNotify
 # REFLECT
 ElementalReflect;Elemental Reflect;FF0000FF
 PhysicalReflect;Physical Reflect;FF0000FF
+# LEECH
+MapMonsterLifeLeechImmunity;Cannot Leech Life/Mana;FF0000FF
 # REGEN
 NoLifeESRegen;No Regen;FF007FFF
 MapPlayerReducedRegen;60%% Less Regen;FF007FFF


### PR DESCRIPTION
For many build it's extremely important to have life and mana leech to complete the map, so I suggest chaning the initial ModWarnings.txt